### PR TITLE
[Fixes] Prints integers without adding null at the beginning

### DIFF
--- a/printf.c
+++ b/printf.c
@@ -79,7 +79,8 @@ int format_i(va_list parameter)
 	j = i;
 	while (j >= 0)
 	{
-		write(1, &a[j], sizeof(char));
+	  if (a[j] != '\0')
+	    write(1, &a[j], sizeof(char));
 		j--;
 	}
 	return (i);


### PR DESCRIPTION
Fixes #4

Prints integers without the Null at the beginning.